### PR TITLE
Fix/cldr locale in _language() function

### DIFF
--- a/class.wp-cldr.php
+++ b/class.wp-cldr.php
@@ -217,7 +217,7 @@ class WP_CLDR {
 	}
 
 	public function _language( $language_code, $locale = null ) {
-		return $this->__( $language_code, $locale, 'languages' );
+		return $this->__( $this->get_CLDR_locale($language_code), $locale, 'languages' );
 	}
 
 	/**

--- a/class.wp-cldr.php
+++ b/class.wp-cldr.php
@@ -217,7 +217,7 @@ class WP_CLDR {
 	}
 
 	public function _language( $language_code, $locale = null ) {
-		return $this->__( $this->get_CLDR_locale($language_code), $locale, 'languages' );
+		return $this->__( $this->get_CLDR_locale( $language_code ), $locale, 'languages' );
 	}
 
 	/**


### PR DESCRIPTION
Converts `$language_code` passed by `_language` to a CLDR locale code so array key lookup in `__()` works. Addresses https://github.com/Automattic/wp-cldr-plugin/issues/21